### PR TITLE
fix error handling on no response requests

### DIFF
--- a/nautobot_plugin_chatops_meraki/worker.py
+++ b/nautobot_plugin_chatops_meraki/worker.py
@@ -442,10 +442,10 @@ def get_clients(dispatcher, org_name=None, device_name=None):
         return prompt_for_device(dispatcher, f"meraki get-clients '{org_name}'", org_name)
     client_list = get_meraki_device_clients(org_name, device_name)
     if len(client_list) == 0:
-        dispatcher.send_markdown(f"There are NO Clients in {device_name}!")
+        dispatcher.send_markdown(f"There are NO Clients on {device_name}!")
         return (
             CommandStatusChoices.STATUS_SUCCEEDED,
-            f"There are NO Clients in {device_name}!",
+            f"There are NO Clients on {device_name}!",
         )
     blocks = [
         *dispatcher.command_response_header(


### PR DESCRIPTION
This standardizes what the worker is going to do for commands that return no data where the command is still successful.  The few commands that don't implement this logic is because the handling would take places previous.  Example switchports will always return ports info assuming the switch exist.  The error handling would be done by the filtering on selecting a switch.